### PR TITLE
Update version check in _about.py

### DIFF
--- a/src/pkg_about/_about.py
+++ b/src/pkg_about/_about.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 from functools import partial
 from email.utils import getaddresses, parseaddr
 
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 13):
     getaddresses = partial(getaddresses, strict=False)
     parseaddr    = partial(parseaddr,    strict=False)
 else: pass  # pragma: no cover


### PR DESCRIPTION
If I haven't missed any details, the if condition seems to be off-by-one.

The documentation[1] states that the `strict` kwarg was added in 3.13. But here, the `partial` adding `strict=True` will act on versions 3.12 and above

[1] https://docs.python.org/3/library/email.utils.html#email.utils.getaddresses